### PR TITLE
Check table existence before define_counter_cache and update_counter_cache

### DIFF
--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -34,6 +34,7 @@ module CustomCounterCache::Model
     end
 
     def update_counter_cache(association, cache_column, options = {})
+      return unless table_exists?
       association  = association.to_sym
       cache_column = cache_column.to_sym
       method_name  = "callback_#{cache_column}".to_sym


### PR DESCRIPTION
``` bash
rake db:migrate
```

fails because of table absence. _define_counter_cache_ and _update_counter_cache_ were flavoured with table existence check.
