### PR TITLE
Specs added for the case when model has counter_cache field

### DIFF
--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -4,19 +4,21 @@ class CounterTest < Test::Unit::TestCase
 
   def setup
     @user = User.create
+    @box = Box.create
   end
-
+  
   def test_default_counter_value
     assert_equal 0, @user.published_count
+    assert_equal 0, @box.green_balls_count
   end
-
+  
   def test_create_and_destroy_counter
     @user.articles.create(:state => 'published')
     assert_equal 1, Counter.count
     @user.destroy
     assert_equal 0, Counter.count
   end
-
+  
   def test_increment_and_decrement_counter_with_conditions
     @article = @user.articles.create(:state => 'unpublished')
     assert_equal 0, @user.published_count
@@ -27,15 +29,26 @@ class CounterTest < Test::Unit::TestCase
     @user.articles.each {|a| a.update_attributes(:state => 'unpublished') }
     assert_equal 0, @user.published_count
   end
+  
+  def test_increment_and_decrement_counter_with_conditions_on_model_with_counter_column
+    @ball = @box.balls.create(color: 'red')
+    assert_equal 0, @box.reload.green_balls_count
+    @ball.update_attribute :color, 'green'
+    assert_equal 1, @box.reload.green_balls_count
+    3.times { |i| @box.balls.create(color: 'green') }
+    assert_equal 4, @box.reload.green_balls_count
+    @box.balls.each {|b| b.update_attributes(color: 'red') }
+    assert_equal 0, @box.reload.green_balls_count
+  end
 
   # Test that an eager loaded
   def test_eager_loading_with_no_counter
     @article = @user.articles.create(:state => 'unpublished')
     user = User.includes(:counters).first
     assert_equal 0, user.published_count
-
+  
   end
-
+  
   def test_eager_loading_with_counter
     @article = @user.articles.create(:state => 'published')
     @user = User.includes(:counters).find(@user.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,14 @@ ActiveRecord::Schema.define(:version => 1) do
     t.integer :value, :null => false, :default => 0
   end
   add_index :counters, [ :countable_id, :countable_type, :key ], :unique => true
+  
+  create_table :boxes do |t|
+    t.integer :green_balls_count, default: 0
+  end
+  create_table :balls do |t|
+    t.belongs_to :box
+    t.string :color, :default => 'red'
+  end
 end
 
 class User < ActiveRecord::Base
@@ -36,4 +44,17 @@ end
 
 class Counter < ActiveRecord::Base
   belongs_to :countable, :polymorphic => true
+end
+
+class Box < ActiveRecord::Base
+  has_many :balls
+  define_counter_cache :green_balls_count do |box|
+    box.balls.green.count
+  end
+end
+
+class Ball < ActiveRecord::Base
+  belongs_to :box
+  scope :green, -> { where(color: 'green') }
+  update_counter_cache :box, :green_balls_count, :if => Proc.new { |ball| ball.color_changed? }
 end


### PR DESCRIPTION
PS: gem with the version 0.1.1 that's hosted on rubygems.org seems to have old gemspec file with broken rails dependency:

```
➜  xxxxx git:(master) ✗ ruby -v
ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin13.0.1]
➜  xxxxx git:(master) ✗ bundle update
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    custom_counter_cache (~> 0.1.1) ruby depends on
      rails (~> 3.1) ruby

    rails (4.0.2)
```
