### PR TITLE
update non-polymorphic association counters less

### DIFF
--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -51,7 +51,7 @@ module CustomCounterCache::Model
       # define callback
       define_method method_name do
         # update old association
-        if send("#{foreign_key}_changed?") || ( !respond_to?("#{association}_type") || send("#{association}_type_changed?") )
+        if send("#{foreign_key}_changed?") || ( reflection.options[:polymorphic] && send("#{association}_type_changed?") )
           old_id = send("#{foreign_key}_was")
           klass = if reflection.options[:polymorphic]
             ( send("#{association}_type_was") || send("#{association}_type") ).constantize


### PR DESCRIPTION
The logic to determine whether an old association's counter needed to be updated was always evaluating true for non-polymorphic associations. This caused the counter to be recalculated twice: once as the old association, and once as the new.

This commit tweaks the logic and attempts to clarify the intent.