### PR TITLE
Patch polymorphic association

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,12 +13,12 @@ namespace :gem do
   end
 
   desc 'Build gem.'
-  task :build => :test do
+  task build: :test do
     system "gem build custom_counter_cache.gemspec"
   end
 
   desc 'Build, tag and push gem.'
-  task :release => :build do
+  task release: :build do
     # tag and push
     system "git tag v#{CustomCounterCache::VERSION}"
     system "git push origin --tags"
@@ -28,4 +28,4 @@ namespace :gem do
 
 end
 
-task :default => 'gem:test'
+task default: 'gem:test'

--- a/lib/custom_counter_cache.rb
+++ b/lib/custom_counter_cache.rb
@@ -1,3 +1,4 @@
+require 'custom_counter_cache/model'
+
 module CustomCounterCache
-  require 'custom_counter_cache/model'
 end

--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -9,7 +9,7 @@ module CustomCounterCache::Model
 
       # counter accessors
       unless column_names.include?(cache_column.to_s)
-        has_many :counters, :as => :countable, :dependent => :destroy
+        has_many :counters, as: :countable, dependent: :destroy
         define_method "#{cache_column}" do
           # check if the counter is loaded
           if counters.loaded? && counter = counters.detect{|c| c.key == cache_column.to_s }
@@ -22,7 +22,7 @@ module CustomCounterCache::Model
           if ( counter = counters.find_by_key(cache_column.to_s) )
             counter.update_attribute :value, count.to_i
           else
-            counters.create :key => cache_column.to_s, :value => count.to_i
+            counters.create key: cache_column.to_s, value: count.to_i
           end
         end
       end

--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -1,11 +1,9 @@
+require 'active_support/concern'
+
 module CustomCounterCache::Model
+  extend ActiveSupport::Concern
 
-  def self.included(base)
-    base.extend ActsAsMethods
-  end
-
-  module ActsAsMethods
-
+  module ClassMethods
     def define_counter_cache(cache_column, &block)
       return unless table_exists?
 
@@ -73,9 +71,7 @@ module CustomCounterCache::Model
       after_update  method_name, options
       after_destroy method_name, options
     end
-
   end
-
 end
 
 ActiveRecord::Base.send :include, CustomCounterCache::Model

--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -44,7 +44,7 @@ module CustomCounterCache::Model
       cache_column = cache_column.to_sym
       method_name  = "callback_#{cache_column}".to_sym
       reflection   = reflect_on_association(association)
-      foreign_key  = reflection.try(:foreign_key) || reflection.options[:foreign_key] || reflection.association_foreign_key
+      foreign_key  = reflection.try(:foreign_key) || reflection.association_foreign_key
 
       # define callback
       define_method method_name do

--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -46,7 +46,7 @@ module CustomCounterCache::Model
       cache_column = cache_column.to_sym
       method_name  = "callback_#{cache_column}".to_sym
       reflection   = reflect_on_association(association)
-      foreign_key  = reflection.options[:foreign_key] || reflection.association_foreign_key
+      foreign_key  = reflection.try(:foreign_key) || reflection.options[:foreign_key] || reflection.association_foreign_key
 
       # define callback
       define_method method_name do

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -14,7 +14,7 @@ class CounterTest < MiniTest::Unit::TestCase
   end
 
   def test_create_and_destroy_counter
-    @user.articles.create(:state => 'published')
+    @user.articles.create(state: 'published')
     assert_equal 1, Counter.count
     @user.destroy
     assert_equal 0, Counter.count
@@ -30,13 +30,13 @@ class CounterTest < MiniTest::Unit::TestCase
   end
 
   def test_increment_and_decrement_counter_with_conditions
-    @article = @user.articles.create(:state => 'unpublished')
+    @article = @user.articles.create(state: 'unpublished')
     assert_equal 0, @user.published_count
     @article.update_attribute :state, 'published'
     assert_equal 1, @user.published_count
-    3.times { |i| @user.articles.create(:state => 'published') }
+    3.times { |i| @user.articles.create(state: 'published') }
     assert_equal 4, @user.published_count
-    @user.articles.each {|a| a.update_attributes(:state => 'unpublished') }
+    @user.articles.each {|a| a.update_attributes(state: 'unpublished') }
     assert_equal 0, @user.published_count
   end
 
@@ -53,26 +53,26 @@ class CounterTest < MiniTest::Unit::TestCase
   end
 
   def test_increment_and_decrement_counter_with_conditions_on_model_with_counter_column
-    @ball = @box.balls.create(:color => 'red')
+    @ball = @box.balls.create(color: 'red')
     assert_equal 0, @box.reload.green_balls_count
     @ball.update_attribute :color, 'green'
     assert_equal 1, @box.reload.green_balls_count
-    3.times { |i| @box.balls.create(:color => 'green') }
+    3.times { |i| @box.balls.create(color: 'green') }
     assert_equal 4, @box.reload.green_balls_count
-    @box.balls.each {|b| b.update_attributes(:color => 'red') }
+    @box.balls.each {|b| b.update_attributes(color: 'red') }
     assert_equal 0, @box.reload.green_balls_count
   end
 
   # Test that an eager loaded
   def test_eager_loading_with_no_counter
-    @article = @user.articles.create(:state => 'unpublished')
+    @article = @user.articles.create(state: 'unpublished')
     user = User.includes(:counters).first
     assert_equal 0, user.published_count
 
   end
 
   def test_eager_loading_with_counter
-    @article = @user.articles.create(:state => 'published')
+    @article = @user.articles.create(state: 'published')
     @user = User.includes(:counters).find(@user.id)
     assert_equal 1, @user.published_count
   end

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -20,6 +20,15 @@ class CounterTest < MiniTest::Unit::TestCase
     assert_equal 0, Counter.count
   end
 
+  def test_create_and_destroy_polymorphic_association_counter
+    @article = @user.articles.create(state: "published")
+    assert_equal 0, @article.comments.size
+    @comment = @article.comments.create(state: "published")
+    assert_equal 1, @article.comments.size
+    @article.destroy
+    assert_equal 0, @article.comments.size
+  end
+
   def test_increment_and_decrement_counter_with_conditions
     @article = @user.articles.create(:state => 'unpublished')
     assert_equal 0, @user.published_count
@@ -29,6 +38,18 @@ class CounterTest < MiniTest::Unit::TestCase
     assert_equal 4, @user.published_count
     @user.articles.each {|a| a.update_attributes(:state => 'unpublished') }
     assert_equal 0, @user.published_count
+  end
+
+  def test_increment_and_decrement_polymorphic_counter_with_conditions
+    @article = @user.articles.create(state: "published")
+    @comment = @article.comments.create(state: "unpublished")
+    assert_equal 0, @article.comments_count
+    @comment.update_attribute :state, "published"
+    assert_equal 1, @article.comments_count
+    3.times { |i| @article.comments.create(state: "published") }
+    assert_equal 4, @article.comments_count
+    @article.comments.each { |c| c.update_attributes(state: "unpublished") }
+    assert_equal 0, @article.comments_count
   end
 
   def test_increment_and_decrement_counter_with_conditions_on_model_with_counter_column

--- a/test/gemfiles/rails-3.1
+++ b/test/gemfiles/rails-3.1
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gemspec :path => "./../.."
+gemspec path: "./../.."
 
 gem 'rails', '~> 3.1.0'

--- a/test/gemfiles/rails-3.2
+++ b/test/gemfiles/rails-3.2
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gemspec :path => "./../.."
+gemspec path: "./../.."
 
 gem 'rails', '~> 3.2.0'

--- a/test/gemfiles/rails-4.0
+++ b/test/gemfiles/rails-4.0
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gemspec :path => "./../.."
+gemspec path: "./../.."
 
 gem 'rails', '~> 4.0.0'

--- a/test/gemfiles/rails-4.1
+++ b/test/gemfiles/rails-4.1
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gemspec :path => "./../.."
+gemspec path: "./../.."
 
 gem 'rails', '~> 4.1.0'

--- a/test/gemfiles/rails-4.2
+++ b/test/gemfiles/rails-4.2
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gemspec :path => "./../.."
+gemspec path: "./../.."
 
 gem 'rails', '~> 4.2.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,15 +5,15 @@ require 'action_view'
 require 'active_record'
 require 'custom_counter_cache'
 
-ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
-ActiveRecord::Schema.define(:version => 1) do
+ActiveRecord::Schema.define(version: 1) do
   create_table :users do |t|
   end
 
   create_table :articles do |t|
     t.belongs_to :user
-    t.string :state, :default => 'unpublished'
+    t.string :state, default: 'unpublished'
   end
 
   create_table :comments do |t|
@@ -23,32 +23,32 @@ ActiveRecord::Schema.define(:version => 1) do
   end
 
   create_table :counters do |t|
-    t.references :countable, :polymorphic => true
-    t.string :key, :null => false
-    t.integer :value, :null => false, :default => 0
+    t.references :countable, polymorphic: true
+    t.string :key, null: false
+    t.integer :value, null: false, default: 0
   end
-  add_index :counters, [ :countable_id, :countable_type, :key ], :unique => true
+  add_index :counters, [ :countable_id, :countable_type, :key ], unique: true
 
   create_table :boxes do |t|
-    t.integer :green_balls_count, :default => 0
+    t.integer :green_balls_count, default: 0
   end
 
   create_table :balls do |t|
     t.belongs_to :box
-    t.string :color, :default => 'red'
+    t.string :color, default: 'red'
   end
 end
 
 class User < ActiveRecord::Base
   has_many :articles, dependent: :destroy
   define_counter_cache :published_count do |user|
-    user.articles.where(:articles => { :state => 'published' }).count
+    user.articles.where(articles: { state: 'published' }).count
   end
 end
 
 class Article < ActiveRecord::Base
   belongs_to :user
-  update_counter_cache :user, :published_count, :if => Proc.new { |article| article.state_changed? }
+  update_counter_cache :user, :published_count, if: Proc.new { |article| article.state_changed? }
   has_many :comments, as: :commentable, dependent: :destroy
   define_counter_cache :comments_count do |article|
     article.comments.where(state: "published").count
@@ -61,7 +61,7 @@ class Comment < ActiveRecord::Base
 end
 
 class Counter < ActiveRecord::Base
-  belongs_to :countable, :polymorphic => true
+  belongs_to :countable, polymorphic: true
 end
 
 class Box < ActiveRecord::Base
@@ -73,6 +73,6 @@ end
 
 class Ball < ActiveRecord::Base
   belongs_to :box
-  scope :green, lambda { where(:color => 'green') }
-  update_counter_cache :box, :green_balls_count, :if => Proc.new { |ball| ball.color_changed? }
+  scope :green, lambda { where(color: 'green') }
+  update_counter_cache :box, :green_balls_count, if: Proc.new { |ball| ball.color_changed? }
 end


### PR DESCRIPTION
# Changes

* Use `reflection.try(:foreign_key)` instead of `reflection.options[:foreign_key]`
* Patch test for polymorphic associations
* Restructure with `ActiveSupport::Concern`
* Updated Ruby 1.9 Hash syntax