### PR TITLE
Find old record by id

### DIFF
--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -56,7 +56,7 @@ module CustomCounterCache::Model
           else
             reflection.klass
           end
-          if ( old_id && record = klass.find(old_id) )
+          if ( old_id && record = klass.find_by(id: old_id) )
             record.send("update_#{cache_column}")
           end
         end


### PR DESCRIPTION
I'm having an issue where, for some reason, when creating a record, the foreign_key association is set to 0 (so if there's a `discussion` which has_many `comments`, then a new `comment.discussion_id_was` is 0, instead of nil.

This fixes that case by not blowing up when the old_id can't be accessed by `klass.find`