### PR TITLE
Rails 4.* support: replace test/unit with minitest

### DIFF
--- a/custom_counter_cache.gemspec
+++ b/custom_counter_cache.gemspec
@@ -17,6 +17,7 @@ spec = Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.add_dependency('rails', RUBY_VERSION < '1.9.3' ? '~> 3.1' : '>= 3.1')
   s.add_development_dependency('sqlite3')
+  s.add_development_dependency('minitest')
   s.test_files = Dir['test/**/*.rb']
   s.rubyforge_project = 'custom_counter_cache'
 end

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -1,6 +1,6 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 
-class CounterTest < Test::Unit::TestCase
+class CounterTest < Minitest::Test
 
   def setup
     @user = User.create

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'test/unit'
+require "minitest/autorun"
 require 'sqlite3'
 require 'action_view'
 require 'active_record'


### PR DESCRIPTION
Fixes the tests for Rails 4.*, since it switched from `Test::Unit` to `Minitest`. 