### PR TITLE
End support for Ruby below 2.*, and convert hashrockets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.4
   - ree
 notifications:
   recipients:

--- a/Rakefile
+++ b/Rakefile
@@ -13,12 +13,12 @@ namespace :gem do
   end
 
   desc 'Build gem.'
-  task :build => :test do
+  task build: :test do
     system "gem build custom_counter_cache.gemspec"
   end
 
   desc 'Build, tag and push gem.'
-  task :release => :build do
+  task release: :build do
     # tag and push
     system "git tag v#{CustomCounterCache::VERSION}"
     system "git push origin --tags"
@@ -28,4 +28,4 @@ namespace :gem do
 
 end
 
-task :default => 'gem:test'
+task default:'gem:test'

--- a/custom_counter_cache.gemspec
+++ b/custom_counter_cache.gemspec
@@ -15,7 +15,7 @@ spec = Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files = Dir['lib/**/*.rb']
   s.required_rubygems_version = '>= 1.3.6'
-  s.add_dependency('rails', RUBY_VERSION < '1.9.3' ? '~> 3.1' : '>= 3.1')
+  s.add_dependency('rails', '>= 3.1')
   s.add_development_dependency('sqlite3')
   s.test_files = Dir['test/**/*.rb']
   s.rubyforge_project = 'custom_counter_cache'

--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -10,20 +10,20 @@ module CustomCounterCache::Model
       return unless table_exists?
       # counter accessors
       unless column_names.include?(cache_column.to_s)
-        has_many :counters, :as => :countable, :dependent => :destroy
+        has_many :counters, as: :countable, dependent: :destroy
         define_method "#{cache_column}" do
           # check if the counter is loaded
           if counters.loaded? && counter = counters.detect{|c| c.key == cache_column.to_s }
             counter.value
           else
-            counters.where(:key => cache_column.to_s).first.try(:value).to_i
+            counters.where(key: cache_column.to_s).first.try(:value).to_i
           end
         end
         define_method "#{cache_column}=" do |count|
-          if ( counter = counters.where(:key => cache_column.to_s).first )
+          if ( counter = counters.where(key: cache_column.to_s).first )
             counter.update_attribute :value, count.to_i
           else
-            counters.create :key => cache_column.to_s, :value => count.to_i
+            counters.create key: cache_column.to_s, value: count.to_i
           end
         end
       end

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -11,33 +11,33 @@ class CounterTest < Test::Unit::TestCase
   end
 
   def test_create_and_destroy_counter
-    @user.articles.create(:state => 'published')
+    @user.articles.create(state: 'published')
     assert_equal 1, Counter.count
     @user.destroy
     assert_equal 0, Counter.count
   end
 
   def test_increment_and_decrement_counter_with_conditions
-    @article = @user.articles.create(:state => 'unpublished')
+    @article = @user.articles.create(state: 'unpublished')
     assert_equal 0, @user.published_count
     @article.update_attribute :state, 'published'
     assert_equal 1, @user.published_count
-    3.times { |i| @user.articles.create(:state => 'published') }
+    3.times { |i| @user.articles.create(state: 'published') }
     assert_equal 4, @user.published_count
-    @user.articles.each {|a| a.update_attributes(:state => 'unpublished') }
+    @user.articles.each {|a| a.update_attributes(state: 'unpublished') }
     assert_equal 0, @user.published_count
   end
 
   # Test that an eager loaded
   def test_eager_loading_with_no_counter
-    @article = @user.articles.create(:state => 'unpublished')
+    @article = @user.articles.create(state: 'unpublished')
     user = User.includes(:counters).first
     assert_equal 0, user.published_count
 
   end
 
   def test_eager_loading_with_counter
-    @article = @user.articles.create(:state => 'published')
+    @article = @user.articles.create(state: 'published')
     @user = User.includes(:counters).find(@user.id)
     assert_equal 1, @user.published_count
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,35 +5,35 @@ require 'action_view'
 require 'active_record'
 require 'custom_counter_cache'
 
-ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
-ActiveRecord::Schema.define(:version => 1) do
+ActiveRecord::Schema.define(version: 1) do
   create_table :users do |t|
   end
   create_table :articles do |t|
     t.belongs_to :user
-    t.string :state, :default => 'unpublished'
+    t.string :state, default: 'unpublished'
   end
   create_table :counters do |t|
-    t.references :countable, :polymorphic => true
-    t.string :key, :null => false
-    t.integer :value, :null => false, :default => 0
+    t.references :countable, polymorphic: true
+    t.string :key, null: false
+    t.integer :value, null: false, default: 0
   end
-  add_index :counters, [ :countable_id, :countable_type, :key ], :unique => true
+  add_index :counters, [ :countable_id, :countable_type, :key ], unique: true
 end
 
 class User < ActiveRecord::Base
   has_many :articles
   define_counter_cache :published_count do |user|
-    user.articles.where(:articles => { :state => 'published' }).count
+    user.articles.where(articles: { state: 'published' }).count
   end
 end
 
 class Article < ActiveRecord::Base
   belongs_to :user
-  update_counter_cache :user, :published_count, :if => Proc.new { |article| article.state_changed? }
+  update_counter_cache :user, :published_count, if: Proc.new { |article| article.state_changed? }
 end
 
 class Counter < ActiveRecord::Base
-  belongs_to :countable, :polymorphic => true
+  belongs_to :countable, polymorphic: true
 end


### PR DESCRIPTION
Ruby 1.9.3 support ended [last February](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/), so I put forth that this gem should not worry about it going forward. I also updated the Hash literal syntax to 1.9-style, since we wouldn't have to worry about <1.9.