### PR TITLE
Use update_column instead of update_attribute to prevent callbacks

### DIFF
--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -20,7 +20,7 @@ module CustomCounterCache::Model
         end
         define_method "#{cache_column}=" do |count|
           if ( counter = counters.find_by_key(cache_column.to_s) )
-            counter.update_attribute :value, count.to_i
+            counter.update_column :value, count.to_i
           else
             counters.create key: cache_column.to_s, value: count.to_i
           end
@@ -30,7 +30,7 @@ module CustomCounterCache::Model
       # counter update method
       define_method "update_#{cache_column}" do
         if self.class.column_names.include?(cache_column.to_s)
-          update_attribute cache_column, block.call(self)
+          update_column cache_column, block.call(self)
         else
           send "#{cache_column}=", block.call(self)
         end


### PR DESCRIPTION
As the title already indicates, I prefer using `update_column` instead of `update_attribute` to prevent additional callbacks in the model. This could of course be a breaking change for some users so it is good to think about this carefully. On the other hand I do not really see a situation where you want the changing counter cache to perform some additional actions through callbacks.

In addition to skipping callbacks, this change also prevents the objects to be touched (set `updated_at`). More information can be found in [this blog](http://www.davidverhasselt.com/set-attributes-in-activerecord/).

Looking forward to hear other opinions on this.