### PR TITLE
Allow specification of callbacks to define

### DIFF
--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -70,10 +70,15 @@ module CustomCounterCache::Model
         end
       end
 
+      skip_callback = Proc.new { |callback, opts|
+        (opts[:except].present? && opts[:except].include?(callback)) ||
+        (opts[:only].present?   && !opts[:only].include?(callback))
+      }
+
       # set callbacks
-      after_create  method_name, options unless Array(options[:except]).include?(:create)
-      after_update  method_name, options unless Array(options[:except]).include?(:update)
-      after_destroy method_name, options unless Array(options[:except]).include?(:destroy)
+      after_create  method_name, options unless skip_callback.call(:create, options)
+      after_update  method_name, options unless skip_callback.call(:update, options)
+      after_destroy method_name, options unless skip_callback.call(:destroy, options)
 
     rescue StandardError => e
       # Support Heroku's database-less assets:precompile pre-deploy step:

--- a/lib/custom_counter_cache/model.rb
+++ b/lib/custom_counter_cache/model.rb
@@ -71,9 +71,9 @@ module CustomCounterCache::Model
       end
 
       # set callbacks
-      after_create  method_name, options
-      after_update  method_name, options
-      after_destroy method_name, options
+      after_create  method_name, options unless Array(options[:except]).include?(:create)
+      after_update  method_name, options unless Array(options[:except]).include?(:update)
+      after_destroy method_name, options unless Array(options[:except]).include?(:destroy)
 
     rescue StandardError => e
       # Support Heroku's database-less assets:precompile pre-deploy step:

--- a/test/counter_test.rb
+++ b/test/counter_test.rb
@@ -77,4 +77,22 @@ class CounterTest < MiniTest::Unit::TestCase
     assert_equal 1, @user.published_count
   end
 
+  def test_except_option
+    @ball = @box.balls.create
+    assert_equal 1, @box.reload.lifetime_balls_count
+    @ball.update(color: 'green')
+    assert_equal 1, @box.reload.lifetime_balls_count
+    @ball.destroy
+    assert_equal 1, @box.reload.lifetime_balls_count
+  end
+
+  def test_only_option
+    @ball = @box.balls.create
+    assert_equal 0, @box.reload.destroyed_balls_count
+    @ball.update(color: 'green')
+    assert_equal 0, @box.reload.destroyed_balls_count
+    @ball.destroy
+    assert_equal 1, @box.reload.destroyed_balls_count
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,8 @@ ActiveRecord::Schema.define(version: 1) do
 
   create_table :boxes do |t|
     t.integer :green_balls_count, default: 0
+    t.integer :lifetime_balls_count, default: 0
+    t.integer :destroyed_balls_count, default: 0
   end
 
   create_table :balls do |t|
@@ -74,10 +76,18 @@ class Box < ApplicationRecord
   define_counter_cache :green_balls_count do |box|
     box.balls.green.count
   end
+  define_counter_cache :lifetime_balls_count do |box|
+    box.lifetime_balls_count + 1
+  end
+  define_counter_cache :destroyed_balls_count do |box|
+    box.destroyed_balls_count + 1
+  end
 end
 
 class Ball < ApplicationRecord
   belongs_to :box
   scope :green, lambda { where(color: 'green') }
   update_counter_cache :box, :green_balls_count, if: Proc.new { |ball| ball.color_changed? }
+  update_counter_cache :box, :lifetime_balls_count, except: [:update, :destroy]
+  update_counter_cache :box, :destroyed_balls_count, only: [:destroy]
 end


### PR DESCRIPTION
Oftentimes, I only care about when a model is created or destroyed, but not when it's updated. For models which are created rarely but updated a lot, this can cause a lot of unnecessary counting and database querying over the lifetime of a model.

This change allows me to specify which callbacks I'd like to define when calling `update_counter_cache`. For example, if I have a discussion, which has many comments, and a comment_count, I can write

```
# discussion.rb
define_counter_cache :comment_count, -> { |d| d.comments.count }
# comment.rb
update_counter_cache :discussion, :comment_count, except: :update
```

I think this is a lot cleaner and more explicit than the existing method, which might be something like
```
# comment.rb
update_counter_cache :discussion, :comment_count, if: :update_cache?
def update_cache
  new_record? || destroyed?
end
```