### PR TITLE
Add Rails 5.2 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ gemfile:
   - test/gemfiles/rails-4.2
   - test/gemfiles/rails-5.0
   - test/gemfiles/rails-5.1
+  - test/gemfiles/rails-5.2
 matrix:
   exclude:
   - rvm: 2.4.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ PLATFORMS
 
 DEPENDENCIES
   custom_counter_cache!
-  sqlite3 (>= 1.3.3)
+  sqlite3 (>= 1.3.3, < 1.4.0)
 
 BUNDLED WITH
    1.16.0

--- a/custom_counter_cache.gemspec
+++ b/custom_counter_cache.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb']
   s.required_rubygems_version = '>= 1.3.6'
   s.add_dependency('rails', '>= 4.0')
-  s.add_development_dependency('sqlite3', '>= 1.3.3')
+  s.add_development_dependency('sqlite3', '>= 1.3.3', '< 1.4.0')
   s.test_files = Dir['test/**/*.rb']
   s.rubyforge_project = 'custom_counter_cache'
 end

--- a/test/gemfiles/rails-5.2
+++ b/test/gemfiles/rails-5.2
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: "./../.."
+
+gem 'rails', '~> 5.2.0'


### PR DESCRIPTION
Tweaked test implementation to use `saved_change_to_attribute?` method on Rails 5.1+.

Note: Travis tests fails with Rails 4.0. That is not related to this PR. (related: #27)